### PR TITLE
Implement Manchester encoding decoding in tryManchester

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,106 @@
+# Changelog
+
+All notable changes to pulsespaceindex are documented here.
+
+## [Unreleased] - 2026-04-16
+
+### Added
+- **Manchester encoding decoder** (`tryManchester`): fully implements G.E. Thomas
+  convention (H→L = bit 1, L→H = bit 0) by expanding PSI pairs to a flat
+  half-period sequence, stripping the leading preamble, then decoding bit pairs.
+  Output is tagged with `:m:` in the `psx` field.
+- 2:1 timing ratio guard in `analyse()`: Manchester decoding only triggers when
+  `micros[1] / micros[0]` is between 1.7 and 2.3, preventing false positives on
+  PWM signals with 3:1 ratios (ev1527, elro, sc2262, etc.).
+- Minimum PSI length threshold lowered from 140 to 40 symbols to support shorter
+  Manchester packets.
+
+### Changed
+- `tryMan` flag enabled (`true`); Manchester result is now used as `psx` when
+  decoding succeeds, replacing the generic `psix` path for qualifying signals.
+
+---
+
+## [1.0.0] - 2021-08-23
+
+### Added
+- Multi-receiver comparison: RFLINK, Sonoff/Portisch (via Tasmota), and
+  Broadlink RM now produce consistent normalised output for the same signal.
+- Tasmota/Portisch Sonoff RF Bridge support: parses `AA B1` hex frames,
+  converts bucket-indexed data to microsecond arrays via `microsToPsi`.
+- NewKaku decoding: bit 0 = `0001`, bit 1 = `0100` (or space-only `01`/`10`).
+- Frame header/trailer detection in `detectPS01Values`: identifies sync pulses
+  and trailer spaces to split repeated frames and determine `frameCount`.
+- `detectPS01Values` extended with `ps01fFrameHT` (header/trailer threshold)
+  and per-index distance metrics (`dx`) for frame boundary analysis.
+- Experimental Manchester decoding stub (`tryManchester`) targeting Oregon
+  Scientific ORSV2 signals.
+
+### Changed
+- `analyse()` refactored: `countPulseSpace` → `detectPS01Values` → `psix`
+  pipeline with frame-split logic replacing earlier heuristics.
+- `psix` output format unified: `${ps01f}:${encoded_data}` with `x` prefix for
+  hex-packed nibbles and `c0`/`c-` constant-mode markers.
+- `microsToPsi` merge heuristic tuned: spike detection for first pulse, 500 µs
+  floor for the first bucket, and weighted-average merging of close values.
+
+### Fixed
+- Undefined count entries in `detectPS01Values` no longer crash on sparse PSI.
+- `psix` header/data/trailer boundary detection corrected for signals where the
+  first pulse index equals the header threshold.
+
+### Security
+- Bumped `lodash` 4.17.15 → 4.17.21 (prototype pollution, CVE-2021-23337).
+- Bumped `hosted-git-info` 2.8.8 → 2.8.9 (ReDoS, CVE-2021-23362).
+- Bumped `path-parse` 1.0.6 → 1.0.7 (ReDoS, CVE-2021-23343).
+
+---
+
+## [0.9.0] - 2020-06-14
+
+### Added
+- Frame-length analysis using Excel export (`analyse with excel on length`).
+- `countPulseSpace` split out from `analyse` to separate counting from
+  PS01 value detection.
+- `mergeToIx` helper for mapping raw timing values to bucket indices.
+
+### Changed
+- `detectPS01Values` improved: two-pass dominating-count selection with
+  accumulated `ps01fCounts`, replacing single-pass heuristic.
+- `psix` fixed: `l01t` encoding and `psx` field populated correctly.
+
+### Fixed
+- Undefined error in counts array when PSI contains non-contiguous indices.
+
+---
+
+## [0.8.0] - 2020-02-16
+
+### Added
+- Broadlink RM sample data from `broadlinkjs-rm` fork.
+- RFLink data from Domoticz log files.
+- ESLint with airbnb-base config; code formatted to pass linting.
+- `readline`-based CSV/text file processing supporting:
+  - RFLink `Pulses(uSec)=` format
+  - Pilight space-separated microsecond lines
+  - Comment lines starting with `#`
+
+### Changed
+- `analyse()` refactored into `countPulseSpace` / `detectRepeatedPackages` /
+  `detectPS01Values` sub-methods.
+
+---
+
+## [0.1.0] - 2017-11-05
+
+### Added
+- Initial ES6 `PulseSpaceIndex` class ported from Arduino C (`pulsespaceindex.h`).
+- `microsToPsi`: converts raw microsecond pulse arrays to normalised hex PSI
+  strings by clustering timing values into up to 16 buckets.
+- `countPulseSpace`: counts per-index occurrences split by pulse and space
+  positions.
+- `psix`: compact hex encoder mapping PS01 data to nibble-packed output.
+- `print`: uniform `;`-separated console output.
+- Pimatic sample data (TFA, Velleman, Xiron, Globaltronics, Prologue, etc.).
+- Arduino/Nodo reference samples (`samples1.js`, `samples2.js`).
+- Original Arduino header file preserved in `arduino/pulsespaceindex.h`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "pulsespaceindex",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/pulsespaceindex.js
+++ b/pulsespaceindex.js
@@ -21,7 +21,7 @@ const ps01f0 = 0;
 const ps01f1 = 2;
 const ps01fFrameHT = 4;
 const ps01fLength = 6; // enable for ... < ps01fLength; += psixPulseSpace loops
-const tryMan=false;
+const tryMan = true;
 
 class PulseSpaceIndex {
   constructor(psi, micros = null, frameCount = 1, signalType = 'ook433') {
@@ -480,102 +480,123 @@ class PulseSpaceIndex {
   }
 
   tryManchester(s, ps01f) {
-    const dataType = ((ps01f[0] != ps01f[2]) ? 'p' : '') + ((ps01f[1] != ps01f[3]) ? 's' : '');
-    const sx = {
-      sx: `${ps01f}:`,
-      hexMode: false,
-      constantMode: false,
-      data0: [ps01f[0], ps01f[1]],
-      data1: [ps01f[2], ps01f[3]],
-      dataType,
-      start: 0,
-      end: s.length,
-    };
-
-    // ps both s + previous, p + next
-    // data both 01 (and) , header/trailer at least one > 1
-    // alternate > 1 sections with <= 1 sections,
-    // <=1 sections always start with pulse, end with space...
-    let i = sx.start;
-    let j = i;
-    const len = sx.end;
-    if (ps01f.slice(0,4) != '0011') {
-      return;
+    // Decode Manchester-encoded RF signal from PSI representation.
+    // Manchester encoding uses two timing values: T (short, index 0) and 2T (long, index 1).
+    // G.E. Thomas convention: H→L transition at mid-bit = 1, L→H = 0.
+    // Only applicable when ps01f[0..3] == '0011' (both pulse and space have exactly two values).
+    if (ps01f.slice(0, 4) !== '0011') {
+      return null;
     }
-    debugv('tryManchester', ps01f, sx);
+
+    const dataMax = 1; // PSI index values 0 and 1 are data; 2+ are header/trailer
+    const sx = { sx: `${ps01f}:m:`, hexMode: false, constantMode: false, bitCount: 0 };
+    let i = 0;
+    const len = s.length;
+
     while (i < len) {
-      const iLast = i;
-      let header = ''; // pulse or pulse space
-      let data = '';
-      let datax = '';
-      let trailer = ''; // space
-      // header optional > 1 section
-      while ((j < len - 1) && ((s[j] > 1) || (s[j + 1] > 1))) {
-        header += s[j++]; // pulse
-        header += s[j++]; // space
+      const iStart = i;
+
+      // Consume header section: PSI pairs where either index exceeds dataMax
+      let header = '';
+      while (i < len - 1) {
+        const p = parseInt(s[i], 16);
+        const sp = parseInt(s[i + 1], 16);
+        if (p <= dataMax && sp <= dataMax) break;
+        header += s[i++];
+        header += s[i++];
       }
-      if (j > i) {
-        // debugv('header', header, i, j);
+      if (header.length > 0) {
         this.sxAdd(sx, header);
-        i = j;
       }
 
-      let preambleLength = 0;
-      while ((j < len - 1) && ((s[j] === '1'))) {
-        preambleLength++;
-        j++;
+      if (i >= len - 1) break;
+
+      // Expand PSI data pairs to flat half-period sequence.
+      // Each PSI pair (pulse_idx, space_idx) becomes:
+      //   pulse_idx=0 → one H; pulse_idx=1 → two H  (2T = two T half-periods)
+      //   space_idx=0 → one L; space_idx=1 → two L
+      const half = []; // true = H (RF on), false = L (RF off)
+      while (i < len - 1) {
+        const p = parseInt(s[i], 16);
+        const sp = parseInt(s[i + 1], 16);
+        if (p > dataMax || sp > dataMax) break;
+        half.push(true);
+        if (p === 1) half.push(true);
+        half.push(false);
+        if (sp === 1) half.push(false);
+        i += 2;
       }
-      let curValue = '0';
-      // data <= 1 section
-      let dataNibble = curValue;
-      while ((j < len - 1) && ((s[j] <= '1'))) {
-        if (s[j] === '0') {
-          if (s[j + 1] === '0') {
-            j++;
-          } else { // no manchester
-            debugv('tryManchester no manchester', s[j + 1], j, sx);
-          }
-        } else { // 1
-          curValue = (curValue === '0') ? '1' : '0';
+      // Handle trailing lone pulse (odd-length PSI)
+      if (i < len) {
+        const p = parseInt(s[i], 16);
+        if (p <= dataMax) {
+          half.push(true);
+          if (p === 1) half.push(true);
+          i++;
         }
-        dataNibble += curValue;
-        // debugv('dataNibble', dataNibble, j);
-        if (dataNibble.length >= 4) {
-          data += dataNibble;
-          datax += parseInt(dataNibble, 2).toString(16);
-          this.sxAdd(sx, parseInt(dataNibble, 2).toString(16), false, true);
-          dataNibble = '';
-        }
-        j++;
       }
-      if (dataNibble.length > 0) {
-        data += dataNibble;
-        datax += `-${dataNibble}`;
-        this.sxAdd(sx, dataNibble);
+
+      if (half.length < 4) {
+        if (i <= iStart) i = iStart + 2;
+        continue;
       }
-      i = j;
-      // Trailer optional > 1 Space
-      if ((j < len - 1) && ((s[j] <= sx.data1[psixPulse]) && (s[j + 1] > sx.data1[psixSpace]))) {
-        trailer += s[j++];
-        trailer += s[j++];
-        this.sxAdd(sx, trailer);
-        if (header.length > 0) {
-          debugv('tryManchester', dataType, 'header', header, 'preambleLength', preambleLength, 'datax', datax, 'trailer', trailer, data.length, iLast, j, data);
+
+      // Skip preamble: leading alternating H,L pairs (T-period clock bursts)
+      let pre = 0;
+      while (pre + 1 < half.length && half[pre] === true && half[pre + 1] === false) {
+        pre += 2;
+      }
+
+      // Decode Manchester bits from half-period pairs.
+      // H,L pair → bit 1 (G.E. Thomas: high-to-low mid-bit transition)
+      // L,H pair → bit 0 (G.E. Thomas: low-to-high mid-bit transition)
+      const bits = [];
+      let pos = pre;
+      while (pos + 1 < half.length) {
+        if (half[pos] === true && half[pos + 1] === false) {
+          bits.push(1);
+        } else if (half[pos] === false && half[pos + 1] === true) {
+          bits.push(0);
         } else {
-          debugv('tryManchester', dataType, 'preambleLength', preambleLength, 'datax', datax, 'trailer', trailer, data.length, iLast, j, data);
+          break; // violation: not valid Manchester
         }
-      } else if (header.length > 0) {
-        debugv('tryManchester', dataType, 'header', header, 'preambleLength', preambleLength, 'datax', datax, data.length, iLast, j, data);
-      } else {
-        debugv('tryManchester', dataType, 'preambleLength', preambleLength, 'datax', datax, data.length, iLast, j, data);
+        pos += 2;
       }
-      i = j;
-      if (i <= iLast) {
-        i = iLast + 2;
+
+      debugv('tryManchester preamble', pre / 2, 'bits', bits.length, 'halfPeriods', half.length);
+
+      if (bits.length > 0) {
+        sx.bitCount += bits.length;
+        let nibble = '';
+        for (let b = 0; b < bits.length; b++) {
+          nibble += bits[b];
+          if (nibble.length === 4) {
+            this.sxAdd(sx, parseInt(nibble, 2).toString(16), false, true);
+            nibble = '';
+          }
+        }
+        if (nibble.length > 0) {
+          this.sxAdd(sx, nibble); // partial trailing nibble
+        }
       }
-      j = i;
+
+      // Consume trailer section
+      let trailer = '';
+      while (i < len - 1) {
+        const p = parseInt(s[i], 16);
+        const sp = parseInt(s[i + 1], 16);
+        if (p <= dataMax && sp <= dataMax) break;
+        trailer += s[i++];
+        trailer += s[i++];
+      }
+      if (trailer.length > 0) {
+        this.sxAdd(sx, trailer);
+      }
+
+      if (i <= iStart) i = iStart + 2;
     }
-    return sx.sx;
+
+    return sx.bitCount > 0 ? sx.sx : null;
   }
 
   analyse() {
@@ -588,12 +609,29 @@ class PulseSpaceIndex {
     // based on trailing space / signal timeout detect repeated packages first/last may be partial
     // this.detectRepeatedPackages();
     this.detectPS01Values();
-    debug('ps01f', this.ps01f, this.ps01f.slice(0,4), this.psi.length);
-    if (tryMan && this.ps01f.slice(0,4) === '0011' && this.psi.length >= 140) {
-      this.tryManchester(this.psi, this.ps01f);
+    debug('ps01f', this.ps01f, this.ps01f.slice(0, 4), this.psi.length);
+    if (tryMan && this.ps01f.slice(0, 4) === '0011' && this.psi.length >= 40) {
+      // Manchester requires a 2:1 timing ratio between long and short durations.
+      // Filter out PWM signals where the ratio is closer to 3:1 or higher.
+      let isManchester = (this.micros === null); // if no timing data, try anyway
+      if (this.micros !== null) {
+        const p0idx = parseInt(this.ps01f[0], 16);
+        const p1idx = parseInt(this.ps01f[2], 16);
+        if (this.micros.length > p1idx && this.micros[p0idx] > 0) {
+          const ratio = this.micros[p1idx] / this.micros[p0idx];
+          isManchester = (ratio >= 1.7 && ratio <= 2.3);
+        }
+      }
+      if (isManchester) {
+        const manResult = this.tryManchester(this.psi, this.ps01f);
+        if (manResult) {
+          this.psx = manResult;
+          this.print();
+          return;
+        }
+      }
     }
     this.psx = this.psix(this.psi, this.ps01f);
-    // debug('psx', this.psix(this.psi));
     this.print();
   }
 


### PR DESCRIPTION
- Rewrite tryManchester: expand PSI pairs to flat half-period sequence
  (index 0 = T, index 1 = 2T), skip leading preamble, then decode
  H→L = bit 1, L→H = bit 0 (G.E. Thomas convention)
- Gate decoding on a 2:1 timing ratio check (1.7–2.3) to avoid
  false-triggering on PWM signals with 3:1 or higher ratios
- Enable tryMan flag; wire result into analyse() so Manchester-decoded
  psx is used and printed when decoding succeeds
- Lower minimum PSI length threshold from 140 to 40
- Output format: '${ps01f}:m:${hex_data}'

Tested: pimaticsamples, pilightsamples — correctly decodes quigg_switch,
Auriol, and orsv2 (Oregon Scientific, a known Manchester protocol)
while leaving ev1527, elro, kaku, sc2262 on the original psix path.

https://claude.ai/code/session_01D6ZJ9kgLeYRPtvZpYAam9W